### PR TITLE
TitleBlock-WB: update icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
 
   <url type="wiki">https://github.com/APEbbers/TitleBlock-WB/wiki</url>
 
-  <icon>Resources/icons/TitleBlockWB.svg</icon>
+  <icon>Resources/Icons/TitleBlockWB.svg</icon>
 
   <content>
     <workbench>


### PR DESCRIPTION
Fix `<icon>` path so it matches [the icon resource](https://github.com/APEbbers/TitleBlock-WB/blob/main/Resources/Icons/TitleBlockWB.svg).